### PR TITLE
Fixed broken image links

### DIFF
--- a/en/course-03/lesson-01/chapter-02/README.md
+++ b/en/course-03/lesson-01/chapter-02/README.md
@@ -24,7 +24,7 @@ while an input contains:
 
 An Unspent Transaction Output (UTXO) is an output not consumed in any transaction yet. The low-level bytecode/opcode is called [Bitcoin Script](https://wiki.bitcoinsv.io/index.php/Script), which is interpreted by the [Bitcoin Virtual Machine](https://xiaohuiliu.medium.com/introduction-to-bitcoin-smart-contracts-9c0ea37dc757) (BVM).
 
-![](https://scrypt.io/assets/images/utxo-a4cf31c29158072cdfbfae3366522ba5.jpg)
+![](https://docs.scrypt.io/assets/images/utxo-a4cf31c29158072cdfbfae3366522ba5.jpg)
 
 In the example above, we have two transactions, each having one input (in green) and one output (in red). And the transaction on the right spends the one on the left.
 The locking script can be regarded as a boolean function `f` that specifies conditions to spend the bitcoins in the UTXO, acting as a lock (thus the name "locking").

--- a/en/course-03/lesson-01/chapter-08/README.md
+++ b/en/course-03/lesson-01/chapter-08/README.md
@@ -5,7 +5,7 @@
 In the UTXO model, the context of validating a smart contract is the UTXO containing it and the transaction spending it, including its inputs and outputs. In the following example, when the second of input of transaction `tx1` is spending the second output of `tx0`, the context for the smart contract in the latter output is roughly the UTXO and `tx1` circled in red.
 
 
-![](https://scrypt.io/assets/images/scriptContext-a3ace5522bf62d82d20958735c13ddf4.jpg)
+![](https://docs.scrypt.io/assets/images/scriptContext-a3ace5522bf62d82d20958735c13ddf4.jpg)
 
 You can directly access the context through `this.ctx` in any public `@method`.
 It can be considered additional information a public method gets when called, besides its function parameters.

--- a/zh/course-03/lesson-01/chapter-02/README.md
+++ b/zh/course-03/lesson-01/chapter-02/README.md
@@ -26,7 +26,7 @@
 
 未花费的交易输出 (UTXO) 是尚未在任何交易中使用的输出。底层计算机代码称为[比特币脚本](https://wiki.bitcoinsv.io/index.php/Script)。
 
-![](https://scrypt.io/assets/images/utxo-a4cf31c29158072cdfbfae3366522ba5.jpg)
+![](https://docs.scrypt.io/assets/images/utxo-a4cf31c29158072cdfbfae3366522ba5.jpg)
 
 
 锁定脚本可以被视为一个布尔函数 `f`，它指定在 UTXO 中花费比特币的条件（因此名称为“锁定”），充当锁。解锁脚本依次提供使 `f` 计算结果为真的函数参数，即解锁所需的“密钥”（也称为见证）。只有当输入包含与先前输出的“锁”匹配的“密钥”时，它才能花费输出中包含的比特币。

--- a/zh/course-03/lesson-01/chapter-08/README.md
+++ b/zh/course-03/lesson-01/chapter-08/README.md
@@ -4,7 +4,7 @@
 
 在 UTXO 模型中，验证的上下文是正在花费的 UTXO 和花费交易，包括它的输入和输出。 在下面的示例中，当交易 `tx1` 的第二个输入花费 `tx0` 的第二个输出时，位于 `tx0` 第二个输出中的智能合约的上下文大致，即 [ScriptContext](https://scrypt.io/docs/how-to-write-a-contract/scriptcontext)，是用红色圈出 UTXO 和用红色圈出的 `tx1`。
 
-![](https://scrypt.io/assets/images/scriptContext-a3ace5522bf62d82d20958735c13ddf4.jpg)
+![](https://docs.scrypt.io/assets/images/scriptContext-a3ace5522bf62d82d20958735c13ddf4.jpg)
 
 
 您可以在任何公共 `@method` 中通过 `this.ctx` 直接访问上下文。它可以被认为是公共方法在调用时获得的附加信息，除了它的函数参数。此上下文在 ScriptContext 接口中表示。


### PR DESCRIPTION
I Googled the filename of the missing image and one of the few matches had a very similar URL but with "docs." at the start of the domain name, so I've edited four image links with this pattern.